### PR TITLE
UI improves, and ask for contract button

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -128,5 +128,6 @@ return [
         'triggerdialog_masId' => null,
         'triggerdialog_rest_user' => null,
         'triggerdialog_rest_password' => null,
+        'triggerdialog_contract_email' => 'print-mailing@deutschepost.de',
     ],
 ];

--- a/Translations/de_DE/messages.ini
+++ b/Translations/de_DE/messages.ini
@@ -4,14 +4,14 @@ plugin.triggerdialog.form.email = Email Address
 plugin.triggerdialog.form.masSecret = Prod JWT Secret
 plugin.triggerdialog.form.rest.user = "User [Benutzername]"
 plugin.triggerdialog.form.rest.password = Authentication Secret
-plugin.triggerdialog.form.contract.help = "To send individual print mailings from campaigns, you must have a contract with Deutsche Post."
-plugin.triggerdialog.form.contract.request = "Request contract"
+plugin.triggerdialog.form.contract.help = "Um individuelle Print Mailings aus Kampagnen zu versenden benötigst du einen Vertrag mit der Deutschen Post. "
+plugin.triggerdialog.form.contract.request = "Vertrag anfordern"
 plugin.triggerdialog.form.contract.email = "Guten Tag\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüssen"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 
 plugin.triggerdialog.form.tab.details = Details
 plugin.triggerdialog.form.tab.variables = Data Mapping
-plugin.triggerdialog.form.tab.variables.hint = "The specification of exactly one variable of the data type 'zip' is mandatory. The variable must contain the postal code for the recipient.<br/>If international items are to be supported for the campaign, exactly one variable of the data type 'countryCode' must be chosen."
+plugin.triggerdialog.form.tab.variables.hint = "Die Angabe von genau einer Variable vom Datentyp 'zip' ist zwingend erforderlich. Die Variable muss die Postleitzahl des Empfängers enthalten.<br/>Wenn für die Kampagne internationale Sendungen unterstützt werden sollen, muss genau eine Variable vom Datentyp 'countryCode' gewählt werden"
 plugin.triggerdialog.open.triggerdialog = Print Mailing Manager
 plugin.triggerdialog.entity_id = Print Mailing
 

--- a/Translations/de_DE/messages.ini
+++ b/Translations/de_DE/messages.ini
@@ -1,54 +1,53 @@
 plugin.triggerdialog.form.masClientId = "MAS Client-ID [Mandanten-ID]"
 plugin.triggerdialog.form.masId = "Marketing Automation System (MAS) ID [partnerSystemIdExt]"
-plugin.triggerdialog.form.email = Email Address
+plugin.triggerdialog.form.email = E-Mail Adresse
 plugin.triggerdialog.form.masSecret = Prod JWT Secret
 plugin.triggerdialog.form.rest.user = "User [Benutzername]"
 plugin.triggerdialog.form.rest.password = Authentication Secret
-plugin.triggerdialog.form.contract.help = "Um individuelle Print Mailings aus Kampagnen zu versenden benötigst du einen Vertrag mit der Deutschen Post. "
+plugin.triggerdialog.form.contract.help = "Um individuelle Print Mailings aus Kampagnen zu versenden, musst du zunächst einen Vertrag mit der Deutschen Post abschließen."
 plugin.triggerdialog.form.contract.request = "Vertrag anfordern"
-plugin.triggerdialog.form.contract.email = "Guten Tag\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüssen"
-plugin.triggerdialog.form.contract.subject = "Neuer Vertrag PrintMailing: %masId%"
+plugin.triggerdialog.form.contract.email = "Guten Tag\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer Print Mailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüssen"
+plugin.triggerdialog.form.contract.subject = "Neuer Vertrag Print Mailing: %masId%"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 
 plugin.triggerdialog.form.tab.details = Details
-plugin.triggerdialog.form.tab.variables = Data Mapping
-plugin.triggerdialog.form.tab.variables.hint = "Die Angabe von genau einer Variable vom Datentyp 'zip' ist zwingend erforderlich. Die Variable muss die Postleitzahl des Empfängers enthalten.<br/>Wenn für die Kampagne internationale Sendungen unterstützt werden sollen, muss genau eine Variable vom Datentyp 'countryCode' gewählt werden"
+plugin.triggerdialog.form.tab.variables = Daten Mapping
+plugin.triggerdialog.form.tab.variables.hint = "Die Angabe von genau einer Variable vom Datentyp 'zip' ist obligatorisch. Die Variable muss die Postleitzahl des Empfängers enthalten.<br/>Wenn für die Kampagne internationale Artikel unterstützt werden sollen, musst du genau eine Variable vom Datentyp 'countryCode' wählen."
 plugin.triggerdialog.open.triggerdialog = Print Mailing Manager
 plugin.triggerdialog.entity_id = Print Mailing
 
-mautic.config.tab.triggerdialogconfig = Print Mailing Settings
+mautic.config.tab.triggerdialogconfig = Print Mailing Einstellungen
 mautic.config.tab.triggerdialogconfig.rest = REST API
 
-plugin.triggerdialog.menu.index = Print Mailing
+plugin.triggerdialog.menu.index = Print Mailing 
 plugin.triggerdialog.menu.root = Print Mailing Templates
-plugin.triggerdialog.menu.edit = Edit Print Mailing Template
-plugin.triggerdialog.menu.new = New Print Mailing Template
+plugin.triggerdialog.menu.edit = Print Mailing Template bearbeiten
+plugin.triggerdialog.menu.new = Neues Print Mailing Template
 
-plugin.triggerdialog.campaign.label = Send via Print Mailing
-plugin.triggerdialog.campaign.description = Send postcard or letter via Print Mailing
+plugin.triggerdialog.campaign.label = Via Print Mailing senden
+plugin.triggerdialog.campaign.description = Postkarte oder Brief via Print Mailing senden
 plugin.triggerdialog.campaign.formlabel = Print Mailing Template
 
-plugin.triggerdialog.campaign.notice.batch_deleted = Deleted multiple Print Mailing templates
-plugin.triggerdialog.campaign.error.notfound = Print Mailing template not found
-plugin.triggerdialog.campaign.error.cannot.delete.batch = Cannot delete multiple Print Mailing templates
+plugin.triggerdialog.campaign.notice.batch_deleted = Mehrere Print Mailing Templates gelöscht
+plugin.triggerdialog.campaign.error.notfound = Print Mailing Template nicht gefunden
+plugin.triggerdialog.campaign.error.cannot.delete.batch = Kann mehrere Print Mailing Templates nicht löschen
 
-mautic.triggerdialog.form.confirmdelete = Do you want to delete this Print Mailing template?
+mautic.triggerdialog.form.confirmdelete = Willst du dieses Print Mailing Template löschen?
 
 plugin.triggerdialog.plugin.name = Print Mailing
-plugin.triggerdialog.config.invalid = Your configuration seems to be invalid. Please check your %link%.
+plugin.triggerdialog.config.invalid = Deine Konfiguration scheint ungültig zu sein. Bitte überprüfe deinen %link%.
 
 
-mautic.triggerdialog.permissions.header = Print Mailing Permissions
-mautic.triggerdialog.permissions.campaigns = Print Mailing Template Permissions
+mautic.triggerdialog.permissions.header = Print Mailing Berechtigungen
+mautic.triggerdialog.permissions.campaigns = Print Mailing Template Berechtigungen
 
 
-plugin.triggerdialog.form.types.string = String
-plugin.triggerdialog.form.types.integer = Integer
-plugin.triggerdialog.form.types.boolean = Boolean
-plugin.triggerdialog.form.types.date = Date
-plugin.triggerdialog.form.types.image = Image
-plugin.triggerdialog.form.types.imageurl = Image URL
-plugin.triggerdialog.form.types.float = Float
-plugin.triggerdialog.form.types.zip = ZIP
-plugin.triggerdialog.form.types.countrycode = Country Code
-
+plugin.triggerdialog.form.types.string = Text
+plugin.triggerdialog.form.types.integer = Ganzzahl
+plugin.triggerdialog.form.types.boolean = Wahr/Falsch
+plugin.triggerdialog.form.types.date = Datum
+plugin.triggerdialog.form.types.image = Bild
+plugin.triggerdialog.form.types.imageurl = Bild URL
+plugin.triggerdialog.form.types.float = Kommazahl
+plugin.triggerdialog.form.types.zip = PLZ
+plugin.triggerdialog.form.types.countrycode = Länder Code

--- a/Translations/de_DE/messages.ini
+++ b/Translations/de_DE/messages.ini
@@ -6,7 +6,7 @@ plugin.triggerdialog.form.rest.user = "User [Benutzername]"
 plugin.triggerdialog.form.rest.password = Authentication Secret
 plugin.triggerdialog.form.contract.help = "Um individuelle Print Mailings aus Kampagnen zu versenden, musst du zunächst einen Vertrag mit der Deutschen Post abschließen."
 plugin.triggerdialog.form.contract.request = "Vertrag anfordern"
-plugin.triggerdialog.form.contract.email = "Guten Tag\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer Print Mailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüssen"
+plugin.triggerdialog.form.contract.email = "Guten Tag,\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer Print Mailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüßen"
 plugin.triggerdialog.form.contract.subject = "Neuer Vertrag Print Mailing: %masId%"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 

--- a/Translations/de_DE/messages.ini
+++ b/Translations/de_DE/messages.ini
@@ -7,6 +7,7 @@ plugin.triggerdialog.form.rest.password = Authentication Secret
 plugin.triggerdialog.form.contract.help = "Um individuelle Print Mailings aus Kampagnen zu versenden benötigst du einen Vertrag mit der Deutschen Post. "
 plugin.triggerdialog.form.contract.request = "Vertrag anfordern"
 plugin.triggerdialog.form.contract.email = "Guten Tag\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüssen"
+plugin.triggerdialog.form.contract.subject = "Neuer Vertrag PrintMailing: %masId%"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 
 plugin.triggerdialog.form.tab.details = Details

--- a/Translations/de_DE/messages.ini
+++ b/Translations/de_DE/messages.ini
@@ -6,7 +6,7 @@ plugin.triggerdialog.form.rest.user = "User [Benutzername]"
 plugin.triggerdialog.form.rest.password = Authentication Secret
 plugin.triggerdialog.form.contract.help = "Um individuelle Print Mailings aus Kampagnen zu versenden, musst du zunächst einen Vertrag mit der Deutschen Post abschließen."
 plugin.triggerdialog.form.contract.request = "Vertrag anfordern"
-plugin.triggerdialog.form.contract.email = "Guten Tag,\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer Print Mailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüßen"
+plugin.triggerdialog.form.contract.email = "Guten Tag,\\r\\n\\r\\nich interessiere mich für die Nutzung von Ihrer Print Mailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüßen"
 plugin.triggerdialog.form.contract.subject = "Neuer Vertrag Print Mailing: %masId%"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -4,9 +4,10 @@ plugin.triggerdialog.form.email = Email Address
 plugin.triggerdialog.form.masSecret = Prod JWT Secret
 plugin.triggerdialog.form.rest.user = "User [Benutzername]"
 plugin.triggerdialog.form.rest.password = Authentication Secret
-plugin.triggerdialog.form.contract.help = "To send individual print mailings from campaigns, you must have a contract with Deutsche Post."
+plugin.triggerdialog.form.contract.help = "To send individual print mailings from campaigns, you must have a contract with Deutsche Post first."
 plugin.triggerdialog.form.contract.request = "Request contract"
 plugin.triggerdialog.form.contract.email = "Guten Tag\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüssen"
+plugin.triggerdialog.form.contract.subject = "Neuer Vertrag PrintMailing: %masId%"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 
 plugin.triggerdialog.form.tab.details = Details

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -6,7 +6,7 @@ plugin.triggerdialog.form.rest.user = "User [Benutzername]"
 plugin.triggerdialog.form.rest.password = Authentication Secret
 plugin.triggerdialog.form.contract.help = "To send individual print mailings from campaigns, you must have a contract with Deutsche Post first."
 plugin.triggerdialog.form.contract.request = "Request contract"
-plugin.triggerdialog.form.contract.email = "Guten Tag\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüssen"
+plugin.triggerdialog.form.contract.email = "Guten Tag,\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüßen"
 plugin.triggerdialog.form.contract.subject = "Neuer Vertrag PrintMailing: %masId%"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 

--- a/Translations/en_US/messages.ini
+++ b/Translations/en_US/messages.ini
@@ -6,7 +6,7 @@ plugin.triggerdialog.form.rest.user = "User [Benutzername]"
 plugin.triggerdialog.form.rest.password = Authentication Secret
 plugin.triggerdialog.form.contract.help = "To send individual print mailings from campaigns, you must have a contract with Deutsche Post first."
 plugin.triggerdialog.form.contract.request = "Request contract"
-plugin.triggerdialog.form.contract.email = "Guten Tag,\\r\\n\\r\\nIch interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüßen"
+plugin.triggerdialog.form.contract.email = "Guten Tag,\\r\\n\\r\\ich interessiere mich für die Nutzung von Ihrer PrintMailing Lösung zusammen mit meinem Marketing Automation Tool. Bitte senden Sie mir einen entsprechenden Vertrag.\\r\\n\\r\\nMAS ID [partnerSystemIdExt]:%masId%\\r\\nMAS Client-ID [Mandanten-ID]: %masClientId%\\r\\n\\r\\nVielen Dank.\\r\\n\\r\\nMit freundlichen Grüßen"
 plugin.triggerdialog.form.contract.subject = "Neuer Vertrag PrintMailing: %masId%"
 plugin.triggerdialog.form.details.link = "https://www.leuchtfeuer.com/en/mautic-know-how/mautic/mautic-postcards-deutschepost-plugin-triggerdialog/"
 

--- a/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
+++ b/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
@@ -68,7 +68,7 @@ $subject = $view['translator']->trans('plugin.triggerdialog.form.contract.subjec
 		event.preventDefault();
         
 		const email = '<?php echo $formConfig['parameters']['triggerdialog_contract_email'] ?>';
-    	const subject = '<?php echo $subject; ?>':
+    	const subject = '<?php echo $subject; ?>';
     	const emailBody = encodeURIComponent('<?php echo $message; ?>');
     	window.location = 'mailto:' + email + '?subject=' + subject + '&body=' +   emailBody;
       }

--- a/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
+++ b/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
@@ -14,7 +14,7 @@ $message = $view['translator']->trans('plugin.triggerdialog.form.contract.email'
 	'%masId%' => $_ENV["MAUTIC_TRIGGERDIALOG_MASID"],
 	'%masClientId%' => $_ENV["MAUTIC_TRIGGERDIALOG_MASCLIENTID"],
 ]);
-$subject = $view['translator']->trans('plugin.triggerdialog.form.contract.subject',['%masId%' => $formConfig['parameters']['triggerdialog_masId']]);
+$subject = $view['translator']->trans('plugin.triggerdialog.form.contract.subject',['%masId%' => $_ENV["MAUTIC_TRIGGERDIALOG_MASID"]]);
 ?>
 
 <div class="panel panel-primary">

--- a/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
+++ b/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
@@ -43,10 +43,10 @@ $message = implode($arrMsg,'\\r\\n');
 		</div>	
 		<div class="row">
 			<div class="col-md-6">
-                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_masId'); ?>
+                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_masClientId'); ?>
 			</div>
 			<div class="col-md-6">
-                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_masClientId'); ?>
+                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_masId'); ?>
 			</div>
 		</div>
 		<hr />

--- a/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
+++ b/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
@@ -14,6 +14,7 @@ $message = $view['translator']->trans('plugin.triggerdialog.form.contract.email'
 	'%masId%' => $_ENV["MAUTIC_TRIGGERDIALOG_MASID"],
 	'%masClientId%' => $_ENV["MAUTIC_TRIGGERDIALOG_MASCLIENTID"],
 ]);
+$subject = $view['translator']->trans('plugin.triggerdialog.form.contract.subject',['%masId%' => $formConfig['parameters']['triggerdialog_masId']]);
 ?>
 
 <div class="panel panel-primary">
@@ -66,10 +67,10 @@ $message = $view['translator']->trans('plugin.triggerdialog.form.contract.email'
       function(event) {
 		event.preventDefault();
         
-		var email = 'print-mailing@deutschepost.de';
-    	var subject = 'Neuer Vertrag PrintMailing: <?php echo $_ENV["MAUTIC_TRIGGERDIALOG_MASID"] ?>';
-    	var emailBody = encodeURIComponent('<?php echo $message; ?>');
+		const email = '<?php echo $formConfig['parameters']['triggerdialog_contract_email'] ?>';
+    	const subject = '<?php echo $subject; ?>':
+    	const emailBody = encodeURIComponent('<?php echo $message; ?>');
     	window.location = 'mailto:' + email + '?subject=' + subject + '&body=' +   emailBody;
       }
     );
-  </script>
+</script>

--- a/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
+++ b/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
@@ -9,24 +9,11 @@ use Mautic\CoreBundle\Templating\Engine\PhpEngine;
 use Symfony\Component\Form\FormView;
 
 $fields    = $form->children;
-// print '<pre>';
-// error_log ('<h1>$this->coreParametersHelper->get()</h1>');
-// error_log( $this->coreParametersHelper->get('triggerdialog_masSecret') );
-// print '</pre>'; 
 
-$arrMsg[] = "Guten Tag";
-$arrMsg[] = "";
-$arrMsg[] = "Ich interessiere mich für die Nutzung von Ihrer PrintMailing Lösung mit dem Marketing Automation Tool Aivie.";
-$arrMsg[] = "";
-$arrMsg[] = "Bitte senden Sie mir einen entsprechenden Vertrag.";
-$arrMsg[] = "";
-$arrMsg[] = sprintf("MAS ID [partnerSystemIdExt]: %s",$_ENV["MAUTIC_TRIGGERDIALOG_MASID"]);
-$arrMsg[] = sprintf("MAS Client-ID [Mandanten-ID]: %s", $_ENV["MAUTIC_TRIGGERDIALOG_MASCLIENTID"]);
-$arrMsg[] = "";
-$arrMsg[] = "Vielen Dank.";
-$arrMsg[] = "";
-$arrMsg[] = "Mit freundlichen Grüssen";
-$message = implode($arrMsg,'\\r\\n');
+$message = $view['translator']->trans('plugin.triggerdialog.form.contract.email',[
+	'%masId%' => $_ENV["MAUTIC_TRIGGERDIALOG_MASID"],
+	'%masClientId%' => $_ENV["MAUTIC_TRIGGERDIALOG_MASCLIENTID"],
+]);
 ?>
 
 <div class="panel panel-primary">
@@ -36,9 +23,9 @@ $message = implode($arrMsg,'\\r\\n');
 	<div class="panel-body">
 		<div class="row">
 			<div class="col-md-6 form-group">
-				<p>Um individuelle Print Mailings aus Kampagnen zu versenden benötigst du einen Vertrag mit der Deutschen Post.</p>
-				<p>Weitere Details und eine <a href="https://aivie.ch/postkarten-versenden-mit-mautic/" target="_blank">Schritt für Schritt Anleitung</a> findest du im Blog.</p>
-				<p><a href="#" class="btn btn-default btn-save btn-copy triggerdialog_mailto">Vertrag anfordern</a></p>
+				<p><?php echo $view['translator']->trans('plugin.triggerdialog.form.contract.help'); ?></p>
+				<p><a href="<?php echo $view['translator']->trans('plugin.triggerdialog.form.details.link'); ?>" target="_blank"><?php echo $view['translator']->trans('plugin.triggerdialog.form.tab.details'); ?> > </a</p>
+				<p><a href="#" class="btn btn-default btn-save btn-copy triggerdialog_mailto"><?php echo $view['translator']->trans('plugin.triggerdialog.form.contract.request'); ?></a></p>
 			</div>
 		</div>	
 		<div class="row">

--- a/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
+++ b/Views/FormTheme/Config/_config_triggerdialogconfig_widget.html.php
@@ -8,6 +8,25 @@
 use Mautic\CoreBundle\Templating\Engine\PhpEngine;
 use Symfony\Component\Form\FormView;
 
+$fields    = $form->children;
+// print '<pre>';
+// error_log ('<h1>$this->coreParametersHelper->get()</h1>');
+// error_log( $this->coreParametersHelper->get('triggerdialog_masSecret') );
+// print '</pre>'; 
+
+$arrMsg[] = "Guten Tag";
+$arrMsg[] = "";
+$arrMsg[] = "Ich interessiere mich für die Nutzung von Ihrer PrintMailing Lösung mit dem Marketing Automation Tool Aivie.";
+$arrMsg[] = "";
+$arrMsg[] = "Bitte senden Sie mir einen entsprechenden Vertrag.";
+$arrMsg[] = "";
+$arrMsg[] = sprintf("MAS ID [partnerSystemIdExt]: %s",$_ENV["MAUTIC_TRIGGERDIALOG_MASID"]);
+$arrMsg[] = sprintf("MAS Client-ID [Mandanten-ID]: %s", $_ENV["MAUTIC_TRIGGERDIALOG_MASCLIENTID"]);
+$arrMsg[] = "";
+$arrMsg[] = "Vielen Dank.";
+$arrMsg[] = "";
+$arrMsg[] = "Mit freundlichen Grüssen";
+$message = implode($arrMsg,'\\r\\n');
 ?>
 
 <div class="panel panel-primary">
@@ -16,17 +35,24 @@ use Symfony\Component\Form\FormView;
 	</div>
 	<div class="panel-body">
 		<div class="row">
+			<div class="col-md-6 form-group">
+				<p>Um individuelle Print Mailings aus Kampagnen zu versenden benötigst du einen Vertrag mit der Deutschen Post.</p>
+				<p>Weitere Details und eine <a href="https://aivie.ch/postkarten-versenden-mit-mautic/" target="_blank">Schritt für Schritt Anleitung</a> findest du im Blog.</p>
+				<p><a href="#" class="btn btn-default btn-save btn-copy triggerdialog_mailto">Vertrag anfordern</a></p>
+			</div>
+		</div>	
+		<div class="row">
 			<div class="col-md-6">
-                <?php echo $view['form']->row($form->children['triggerdialog_masId']); ?>
+                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_masId'); ?>
 			</div>
 			<div class="col-md-6">
-                <?php echo $view['form']->row($form->children['triggerdialog_masClientId']); ?>
+                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_masClientId'); ?>
 			</div>
 		</div>
 		<hr />
 		<div class="row">
 			<div class="col-md-12">
-                <?php echo $view['form']->row($form->children['triggerdialog_masSecret']); ?>
+                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_masSecret'); ?>
 			</div>
 		</div>
 	</div>
@@ -39,11 +65,24 @@ use Symfony\Component\Form\FormView;
 	<div class="panel-body">
 		<div class="row">
 			<div class="col-md-6">
-                <?php echo $view['form']->row($form->children['triggerdialog_rest_user']); ?>
+                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_rest_user'); ?>
 			</div>
 			<div class="col-md-6">
-                <?php echo $view['form']->row($form->children['triggerdialog_rest_password']); ?>
+                <?php echo $view['form']->rowIfExists($fields, 'triggerdialog_rest_password'); ?>
 			</div>
 		</div>
 	</div>
 </div>
+
+<script>
+  mQuery("a.triggerdialog_mailto").click(
+      function(event) {
+		event.preventDefault();
+        
+		var email = 'print-mailing@deutschepost.de';
+    	var subject = 'Neuer Vertrag PrintMailing: <?php echo $_ENV["MAUTIC_TRIGGERDIALOG_MASID"] ?>';
+    	var emailBody = encodeURIComponent('<?php echo $message; ?>');
+    	window.location = 'mailto:' + email + '?subject=' + subject + '&body=' +   emailBody;
+      }
+    );
+  </script>


### PR DESCRIPTION
This will add a new button to the Print Mailing Settings that allows users to directly contact Deutsche Post for a new contract.

In addition, it adds some explanatory text and a link to the blog post for more details.

It also starts the translation to German. Will add some more commits later.