### PR TITLE
fixed-php8-incompatibility

### DIFF
--- a/Controller/TriggerCampaignController.php
+++ b/Controller/TriggerCampaignController.php
@@ -418,7 +418,7 @@ class TriggerCampaignController extends AbstractFormController
 
     protected function redirectToLastPage(int $count, int $limit): Response
     {
-        $lastPage = (1 === $count) ? 1 : (ceil($count / $limit)) ?: 1;
+        $lastPage = ((1 === $count) ? 1 : (ceil($count / $limit))) ?: 1;
         $this->session->set(self::SESSION_VARS['search'], $lastPage);
         $viewParameters = ['page' => $lastPage];
 


### PR DESCRIPTION
Problem: 
plugin is incompatible to php 8 (compare issue #34)

Plugin does not work if change php version to 8.0.8 - The following errors can be found in logs: 
[2022-11-16 09:27:51] mautic.ERROR: PHP Notice: Unparenthesized `a ? b : c ?: d` is not supported. Use either `(a ? b : c) ?: d` or `a ? b : (c ?: d)`
[2022-11-16 09:27:51] mautic.ERROR: Symfony\Component\Debug\Exception\FatalErrorException: Notice: Unparenthesized `a ? b : c ?: d` is not supported. Use either `(a ? b : c) ?: d` or `a ? b : (c ?: d)`

Solution:
Spelling of ternary operator is deprecated and not supported by php 8 in line 421; if changing the line 421 it fixes this problem